### PR TITLE
Implement buffered random byte generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
 # Changelog
 
-No releases yet.
+## v0.2.0 (2022-09-24) _unreleased_
+
+- Added `bufferedRandom`, which calls `crypto.getRandomBytes` in blocks instead of on every UUID generation call, to improve performance significantly.
+- Changed the signature of `EntropySource` to accept the number of desired random bytes.
+
+## v0.1.0 (2022-09-23)
+
+- Initial release
+- Wrote the [readme](./README.md)


### PR DESCRIPTION
This improves performance by about 50%:

| Benchmark suite | Current: fd41d6b63e76962d964950bccb075177c4c8a0e5 | Previous: f06f4791d47f4028f548f4cdae535ec3e8cc01a1 | Ratio |
|-|-|-|-|
| `random` | `426428` ops/sec (`±1.47%`) | `177951` ops/sec (`±0.48%`) | `0.42` |
| `monotonic` | `447592` ops/sec (`±2.25%`) | `202665` ops/sec (`±0.26%`) | `0.45` |