### PR TITLE
Recognize `0` and `0xff` as literal `entropy` options

### DIFF
--- a/src/mod.test.ts
+++ b/src/mod.test.ts
@@ -38,6 +38,11 @@ test('generates monotonic UUIDs', (t) => {
   t.deepEqual(ids, sorted);
 });
 
+test('generates zero-entropy UUIDs', (t) => {
+  const time = 0x18abdfe4693;
+  t.is(uuid({ time, entropy: 0 }), '018abdfe-4693-7000-8000-000000000000');
+});
+
 test('parses the timestamp field', (t) => {
   t.is(timestamp('017f22e2-79b0-7cc3-98c4-dc0c0c07398f'), 0x17f22e279b0);
   t.is(timestamp('017F22E2-79B0-7CC3-98C4-DC0C0C07398F'), 0x17f22e279b0);

--- a/src/mod.test.ts
+++ b/src/mod.test.ts
@@ -41,6 +41,7 @@ test('generates monotonic UUIDs', (t) => {
 test('generates zero-entropy UUIDs', (t) => {
   const time = 0x18abdfe4693;
   t.is(uuid({ time, entropy: 0 }), '018abdfe-4693-7000-8000-000000000000');
+  t.is(uuid({ time, entropy: 0xff }), '018abdfe-4693-7fff-bfff-ffffffffffff');
 });
 
 test('parses the timestamp field', (t) => {

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -16,8 +16,8 @@
  *              `false` to omit them. (default: `true`)
  * - `upper`:   Capitalize the A-F characters in the UUID. (default: `false`)
  * - `version`: The value of the UUID `version` field (default: `7`)
- * - `entropy`: A function to generate the random part of the UUID. Must return
- *              a `Uint8Array` containing 10 bytes.
+ * - `entropy`: A {@link EntropySource function} to generate the random part of
+ *              the UUID, or `0` to set all random bits in the UUID to 0.
  *              (default: uses `crypto.getRandomValues`)
  */
 export const v7: Generator = (opt?: Clock | Time | Options | null): string => {
@@ -31,7 +31,8 @@ export const v7: Generator = (opt?: Clock | Time | Options | null): string => {
     if (opt.dashes != null) dashes = opt.dashes;
     if (opt.version != null) version = (opt.version & 0x0f) << 4;
     if (opt.upper != null) upper = opt.upper;
-    if (opt.entropy != null) rand = opt.entropy;
+    if (opt.entropy != null)
+      rand = opt.entropy !== 0 ? opt.entropy : (n) => new Uint8Array(n);
   }
 
   let timestamp = hex(time, 12);
@@ -135,7 +136,7 @@ export interface Options extends FormatOptions {
    * Generate the random part of the UUID. The returned `Uint8Array` must be at
    * least 10 bytes long.
    */
-  entropy?: EntropySource;
+  entropy?: EntropySource | 0;
 }
 
 /** Configures a UUID {@link generator}. */


### PR DESCRIPTION
An idiom evolved for this in production code:

```ts
uuid({
  entropy: (n) => new Uint8Array(n),
})
```

useful for database cursors, etc.